### PR TITLE
Added error handling.

### DIFF
--- a/src/exitmap.py
+++ b/src/exitmap.py
@@ -201,8 +201,10 @@ def main():
                                        args.first_hop)
 
     for module_name in args.module:
-        run_module(module_name, args, controller, stats)
-
+        try:
+            run_module(module_name, args, controller, stats)
+        except error.ExitSelectionError as err:
+            logger.error("failed to run because : %s" %err)
     return 0
 
 


### PR DESCRIPTION
If no exit relays allowed exit to specified address the script would exit with this output.
2014-10-24 14:39:21,041 [INFO]: 0 UK exits out of all 1153 exit relays allow exiting to [('38.229.72.22', 443)].
Traceback (most recent call last):
  File "./exitmap", line 32, in <module>
    exit(main())
  File "/home/<user>/exitmap/src/exitmap.py", line 205, in main
    run_module(module_name, args, controller, stats)
  File "/home/<user>/exitmap/src/exitmap.py", line 277, in run_module
    "but need at least one." % count)
error.ExitSelectionError: Exit selection yielded 0 exits but need at least one.
This change now lets it exit with the below output.
2014-10-24 14:55:40,027 [INFO]: 0 UK exits out of all 1153 exit relays allow exiting to [('38.229.72.22', 443)].
2014-10-24 14:55:40,032 [ERROR]: failed to run because: Exit selection yielded 0 exits but need at least one.
