### PR TITLE
Misc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 .coverage
 venv/
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - "2.7"
     - "3.3"
     - "3.4"
+    - "3.5"
     - "pypy"
 install:
     - pip install -r requirements.txt

--- a/src/exitmap.py
+++ b/src/exitmap.py
@@ -241,8 +241,8 @@ def main():
     cached_consensus_path = os.path.join(args.tor_dir, "cached-consensus")
     if args.first_hop and (not util.relay_in_consensus(args.first_hop,
                                                        cached_consensus_path)):
-        logger.critical("Given first hop \"%s\" not found in consensus.  Is it "
-                        "offline?" % args.first_hop)
+        logger.critical("Given first hop \"%s\" not found in consensus.  Is it"
+                        " offline?" % args.first_hop)
         return 1
 
     for module_name in args.module:
@@ -254,7 +254,7 @@ def main():
         try:
             run_module(module_name, args, controller, socks_port, stats)
         except error.ExitSelectionError as err:
-            logger.error("failed to run because : %s" % err)
+            logger.error("Failed to run because : %s" % err)
     return 0
 
 
@@ -283,11 +283,11 @@ def select_exits(args, module):
         # '-E' was used to specify a file containing exit relays
 
         try:
-           exit_relays = [line.strip() for line in open(args.exit_file)]
-           total = len(exit_relays)
+            exit_relays = [line.strip() for line in open(args.exit_file)]
+            total = len(exit_relays)
         except Exception as err:
-           logger.error("Could not read file %s", args.exit_file)
-           sys.exit(1)
+            logger.error("Could not read file %s", args.exit_file)
+            sys.exit(1)
     else:
         good_exits = False if (args.all_exits or args.bad_exits) else True
         total, exit_relays = relayselector.get_exits(args.tor_dir,


### PR DESCRIPTION
- Adds python 3.5 to the test runner for future considerations
- Updates the `.gitignore` to now include `__pycache__` which is a file generated when running tests
- Fixes an error's text `failed to run` => `Failed to run`
- Fixes minor pep8 violations having to do with spacing not being a multiple of four and a line exceeding the character count by 1