### PR TITLE
create /tmp/<user>/exitmap_tor_datadir by default.

### DIFF
--- a/src/exitmap.py
+++ b/src/exitmap.py
@@ -149,10 +149,10 @@ def parse_cmd_args():
     parser.add_argument("-d", "--build-delay", type=float, default=3,
                         help="Wait for the given delay (in seconds) between "
                              "circuit builds.  The default is 3.")
-    # Create /tmp/<user>/exitmap_tor_datadir to allow many users to run
+    # Create /tmp/exitmap_tor_datadir-<user> to allow many users to run
     #  exitmap concurrently by default.
 
-    tor_directory = "/tmp" + "/exitmap_tor_datadir/" + pwd.getpwuid(os.getuid())[0]
+    tor_directory = "/tmp" + "/exitmap_tor_datadir-" + pwd.getpwuid(os.getuid())[0]
 
     parser.add_argument("-t", "--tor-dir", type=str,
                         default=tor_directory,

--- a/src/exitmap.py
+++ b/src/exitmap.py
@@ -152,7 +152,8 @@ def parse_cmd_args():
     # Create /tmp/<user>/exitmap_tor_datadir to allow many users to run
     #  exitmap concurrently by default.
 
-    tor_directory = "/tmp/" + pwd.getpwuid(os.getuid())[0] + "/exitmap_tor_datadir"
+    tor_directory = "/tmp" + "/exitmap_tor_datadir/" + pwd.getpwuid(os.getuid())[0]
+
     parser.add_argument("-t", "--tor-dir", type=str,
                         default=tor_directory,
                         help="Tor's data directory.  If set, the network "

--- a/src/exitmap.py
+++ b/src/exitmap.py
@@ -30,6 +30,7 @@ import random
 import logging
 import ConfigParser
 import functools
+import pwd
 
 import stem
 import stem.connection
@@ -148,8 +149,10 @@ def parse_cmd_args():
     parser.add_argument("-d", "--build-delay", type=float, default=3,
                         help="Wait for the given delay (in seconds) between "
                              "circuit builds.  The default is 3.")
+    # Create /tmp/<user>/exitmap_tor_datadir to allow many users to run
+    #  exitmap concurrently by default.
 
-    tor_directory = "/tmp/exitmap_tor_datadir"
+    tor_directory = "/tmp/" + pwd.getpwuid(os.getuid())[0] + "/exitmap_tor_datadir"
     parser.add_argument("-t", "--tor-dir", type=str,
                         default=tor_directory,
                         help="Tor's data directory.  If set, the network "


### PR DESCRIPTION
This allows multiple users can run exitmap concurrently on the same VM/physical box. Right now, you hit permission issue as every user writes/reads to /tmp/exitmap_tor_datadir.

Feedback welcomed on the patch.

