### PR TITLE
Allow multiple users on the same machine/VM to run exitmap

### DIFF
--- a/src/exitmap.py
+++ b/src/exitmap.py
@@ -30,6 +30,7 @@ import random
 import logging
 import ConfigParser
 import functools
+import pwd
 
 import stem
 import stem.connection
@@ -149,7 +150,11 @@ def parse_cmd_args():
                         help="Wait for the given delay (in seconds) between "
                              "circuit builds.  The default is 3.")
 
-    tor_directory = "/tmp/exitmap_tor_datadir"
+    # Create /tmp/exitmap_tor_datadir-<user> to allow many users to run
+    #  exitmap concurrently by default.
+
+    tor_directory = "/tmp" + "/exitmap_tor_datadir-" + pwd.getpwuid(os.getuid())[0]
+
     parser.add_argument("-t", "--tor-dir", type=str,
                         default=tor_directory,
                         help="Tor's data directory.  If set, the network "


### PR DESCRIPTION
by creatin tmp file as
/tmp/exitmap_tor_datadir-<user>
Based on feedback by Philipp with style fixes.

(issue spotted by codarren@hackers.mu)