### PR TITLE
Fixes pep8 violations and cleans up code (#22)(#53)

### DIFF
--- a/src/eventhandler.py
+++ b/src/eventhandler.py
@@ -23,7 +23,6 @@ import sys
 import functools
 import threading
 import multiprocessing
-import socket
 import logging
 
 import stem

--- a/src/exitmap.py
+++ b/src/exitmap.py
@@ -324,11 +324,11 @@ def select_exits(args, module):
 
     exit_destinations = relayselector.get_exits(
         args.tor_dir,
-        good_exit=args.all_exits or (not args.bad_exits),
-        bad_exit=args.all_exits or args.bad_exits,
-        country_code=args.country,
-        requested_exits=requested_exits,
-        destinations=destinations)
+        good_exit       = args.all_exits or (not args.bad_exits),
+        bad_exit        = args.all_exits or args.bad_exits,
+        country_code    = args.country,
+        requested_exits = requested_exits,
+        destinations    = destinations)
 
     log.debug("Successfully selected exit relays after %s." %
               str(datetime.datetime.now() - before))

--- a/src/exitmap.py
+++ b/src/exitmap.py
@@ -151,8 +151,8 @@ def parse_cmd_args():
 
     parser.add_argument("-n", "--delay-noise", type=float, default=0,
                         help="Sample random value in [0, DELAY_NOISE) and "
-                             "randomly add it to or subtract it from the build "
-                             "delay.  This randomises the build delay.  The "
+                             "randomly add it to or subtract it from the build"
+                             " delay.  This randomises the build delay.  The "
                              "default is 0.")
 
     # Create /tmp/exitmap_tor_datadir-$USER to allow many users to run
@@ -275,6 +275,7 @@ def main():
             log.error("Failed to run because : %s" % err)
     return 0
 
+
 def lookup_destinations(module):
     """
     Determine the set of destinations that the module might like to scan.
@@ -291,6 +292,7 @@ def lookup_destinations(module):
                 destinations.add((addrs[host], port))
 
     return destinations
+
 
 def select_exits(args, module):
     """
@@ -322,16 +324,17 @@ def select_exits(args, module):
 
     exit_destinations = relayselector.get_exits(
         args.tor_dir,
-        good_exit       = args.all_exits or (not args.bad_exits),
-        bad_exit        = args.all_exits or args.bad_exits,
-        country_code    = args.country,
-        requested_exits = requested_exits,
-        destinations    = destinations)
+        good_exit=args.all_exits or (not args.bad_exits),
+        bad_exit=args.all_exits or args.bad_exits,
+        country_code=args.country,
+        requested_exits=requested_exits,
+        destinations=destinations)
 
     log.debug("Successfully selected exit relays after %s." %
               str(datetime.datetime.now() - before))
 
     return exit_destinations
+
 
 def run_module(module_name, args, controller, socks_port, stats):
     """

--- a/src/relayselector.py
+++ b/src/relayselector.py
@@ -82,6 +82,7 @@ def get_fingerprints(cached_consensus_path, exclude=[]):
 
     return fingerprints
 
+
 def get_exit_policies(cached_descriptors_path):
     """Read all relays' full exit policies from "cached_descriptors"."""
 
@@ -190,7 +191,7 @@ def get_exits(data_dir,
         return {}
 
     if bad_exit and good_exit:
-        pass # All exits are either bad or good.
+        pass  # All exits are either bad or good.
     elif bad_exit:
         exit_candidates = [
             desc for desc in exit_candidates
@@ -217,9 +218,9 @@ def get_exits(data_dir,
     if address or nickname or version or requested_exits:
         exit_candidates = [
             desc for desc in exit_candidates
-            if ((not address  or address  in desc.address) and
+            if ((not address or address in desc.address) and
                 (not nickname or nickname in desc.nickname) and
-                (not version  or version  == str(desc.tor_version)) and
+                (not version or version == str(desc.tor_version)) and
                 (not requested_exits or desc.fingerprint in requested_exits))
         ]
     if not exit_candidates:
@@ -246,12 +247,14 @@ def get_exits(data_dir,
             dictionary of the form { fingerprint : set(...) }.
             """
             def __nonzero__(self): return True
+
             def __contains__(self, obj): return True
             # __len__ is obliged to return a positive integer.
+
             def __len__(self): return sys.maxsize
         us = UniversalSet()
         exit_destinations = {
-            desc.fingerprint: us for desc in exit_candidates }
+            desc.fingerprint: us for desc in exit_candidates}
     else:
         exit_destinations = {}
         for desc in exit_candidates:
@@ -270,12 +273,12 @@ def main():
     args = parse_cmd_args()
 
     exits = get_exits(args.data_dir,
-                      country_code = args.countrycode,
-                      bad_exit     = args.badexit,
-                      good_exit    = args.goodexit,
-                      version      = args.version,
-                      nickname     = args.nickname,
-                      address      = args.address)
+                      country_code=args.countrycode,
+                      bad_exit=args.badexit,
+                      good_exit=args.goodexit,
+                      version=args.version,
+                      nickname=args.nickname,
+                      address=args.address)
     for e in exits.keys():
         print("https://atlas.torproject.org/#details/%s" % e)
 

--- a/src/relayselector.py
+++ b/src/relayselector.py
@@ -249,8 +249,8 @@ def get_exits(data_dir,
             def __nonzero__(self): return True
 
             def __contains__(self, obj): return True
-            # __len__ is obliged to return a positive integer.
 
+            # __len__ is obliged to return a positive integer.
             def __len__(self): return sys.maxsize
         us = UniversalSet()
         exit_destinations = {
@@ -273,12 +273,12 @@ def main():
     args = parse_cmd_args()
 
     exits = get_exits(args.data_dir,
-                      country_code=args.countrycode,
-                      bad_exit=args.badexit,
-                      good_exit=args.goodexit,
-                      version=args.version,
-                      nickname=args.nickname,
-                      address=args.address)
+                      country_code = args.countrycode,
+                      bad_exit     = args.badexit,
+                      good_exit    = args.goodexit,
+                      version      = args.version,
+                      nickname     = args.nickname,
+                      address      = args.address)
     for e in exits.keys():
         print("https://atlas.torproject.org/#details/%s" % e)
 

--- a/src/six.py
+++ b/src/six.py
@@ -7,8 +7,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/src/torsocks.py
+++ b/src/torsocks.py
@@ -20,7 +20,6 @@ Provide a Tor-specific SOCKSv5 interface.
 """
 
 import os
-import sys
 import struct
 import socket
 import select
@@ -56,16 +55,17 @@ if not hasattr(errno, "ENOTSUP"):
 # Map server-side SOCKSv5 errors to errno codes (as best we can; codes
 # 1 and 7 don't correspond to documented error codes for connect(2))
 socks5_errors = {
-    0x00: 0,                  # Success
-    0x01: errno.EIO,          # General failure
-    0x02: errno.EACCES,       # Connection not allowed by ruleset
-    0x03: errno.ENETUNREACH,  # Network unreachable
-    0x04: errno.EHOSTUNREACH, # Host unreachable
-    0x05: errno.ECONNREFUSED, # Connection refused by destination host
-    0x06: errno.ETIMEDOUT,    # TTL expired
-    0x07: errno.ENOTSUP,      # Command not supported / protocol error
-    0x08: errno.EAFNOSUPPORT, # Address type not supported
+    0x00: 0,                   # Success
+    0x01: errno.EIO,           # General failure
+    0x02: errno.EACCES,        # Connection not allowed by ruleset
+    0x03: errno.ENETUNREACH,   # Network unreachable
+    0x04: errno.EHOSTUNREACH,  # Host unreachable
+    0x05: errno.ECONNREFUSED,  # Connection refused by destination host
+    0x06: errno.ETIMEDOUT,     # TTL expired
+    0x07: errno.ENOTSUP,       # Command not supported / protocol error
+    0x08: errno.EAFNOSUPPORT,  # Address type not supported
 }
+
 
 def send_queue(sock_name):
     """
@@ -76,6 +76,7 @@ def send_queue(sock_name):
     assert (queue is not None) and (circ_id is not None)
 
     queue.put([circ_id, sock_name])
+
 
 class _Torsocket(orig_socket):
 
@@ -210,7 +211,7 @@ class _Torsocket(orig_socket):
 
         dst_addr, dst_port = addr_tuple[0], int(addr_tuple[1])
         self._connecting = True
-        self._peer_addr  = (dst_addr, dst_port)
+        self._peer_addr = (dst_addr, dst_port)
 
         log.debug("Requesting connection to %s:%d.", dst_addr, dst_port)
 
@@ -292,6 +293,7 @@ class _Torsocket(orig_socket):
     def send(self, *args):
         self._maybe_finish_socks_handshake()
         return self._sock.send(*args)
+
     def sendall(self, *args):
         self._maybe_finish_socks_handshake()
         return self._sock.sendall(*args)
@@ -299,6 +301,7 @@ class _Torsocket(orig_socket):
     def recv(self, *args):
         self._maybe_finish_socks_handshake()
         return self._sock.recv(*args)
+
     def recv_into(self, *args):
         self._maybe_finish_socks_handshake()
         return self._sock.recv_into(*args)
@@ -310,12 +313,16 @@ class _Torsocket(orig_socket):
 
     # These sockets can only be used as client sockets.
     def accept(self): raise NotImplementedError
-    def bind(self):   raise NotImplementedError
+
+    def bind(self): raise NotImplementedError
+
     def listen(self): raise NotImplementedError
 
     # These sockets can only be used as connected sockets.
     def sendto(self, *a): raise NotImplementedError
+
     def recvfrom(self, *a): raise NotImplementedError
+
     def recvfrom_into(self, *a): raise NotImplementedError
 
     # Provide information about the ultimate destination, not the
@@ -332,7 +339,7 @@ class _Torsocket(orig_socket):
             if self._connecting:
                 err = self._attempt_finish_socks_handshake()
                 if err == errno.EINPROGRESS:
-                    return 0 # there's no pending connection error yet
+                    return 0  # there's no pending connection error yet
 
             if self._conn_err is not None:
                 err = self._conn_err
@@ -367,6 +374,7 @@ def torsocket(family=socket.AF_INET, type=socket.SOCK_STREAM,
                            os.strerror(errno.EPROTONOSUPPORT))
 
     return _Torsocket(family, type, proto, _sock)
+
 
 class MonkeyPatchedSocket(object):
     """


### PR DESCRIPTION
This is a broad cleanup of pep8 violations.  It fixes ~78 pep8 violations.

Pep8 violations before:

```
./src/util.py:186:18: E127 continuation line over-indented for visual indent
./src/torsocks.py:23:1: F401 'sys' imported but unused
./src/torsocks.py:36:6: E221 multiple spaces before operator
./src/torsocks.py:37:8: E221 multiple spaces before operator
./src/torsocks.py:63:30: E261 at least two spaces before inline comment
./src/torsocks.py:64:30: E261 at least two spaces before inline comment
./src/torsocks.py:67:30: E261 at least two spaces before inline comment
./src/torsocks.py:70:1: E302 expected 2 blank lines, found 1
./src/torsocks.py:80:1: E302 expected 2 blank lines, found 1
./src/torsocks.py:95:23: E221 multiple spaces before operator
./src/torsocks.py:97:24: E221 multiple spaces before operator
./src/torsocks.py:98:24: E221 multiple spaces before operator
./src/torsocks.py:99:23: E221 multiple spaces before operator
./src/torsocks.py:192:22: E128 continuation line under-indented for visual indent
./src/torsocks.py:213:24: E221 multiple spaces before operator
./src/torsocks.py:218:22: E128 continuation line under-indented for visual indent
./src/torsocks.py:258:80: E501 line too long (80 > 79 characters)
./src/torsocks.py:295:5: E301 expected 1 blank line, found 0
./src/torsocks.py:302:5: E301 expected 1 blank line, found 0
./src/torsocks.py:313:5: E301 expected 1 blank line, found 0
./src/torsocks.py:313:20: E272 multiple spaces before keyword
./src/torsocks.py:314:5: E301 expected 1 blank line, found 0
./src/torsocks.py:318:5: E301 expected 1 blank line, found 0
./src/torsocks.py:319:5: E301 expected 1 blank line, found 0
./src/torsocks.py:335:29: E261 at least two spaces before inline comment
./src/torsocks.py:371:1: E302 expected 2 blank lines, found 1
./src/torsocks.py:378:20: E221 multiple spaces before operator
./src/torsocks.py:379:22: E221 multiple spaces before operator
./src/torsocks.py:380:25: E221 multiple spaces before operator
./src/torsocks.py:381:25: E221 multiple spaces before operator
./src/torsocks.py:383:25: E221 multiple spaces before operator
./src/torsocks.py:384:27: E221 multiple spaces before operator
./src/torsocks.py:387:26: E221 multiple spaces before operator
./src/torsocks.py:393:25: E221 multiple spaces before operator
./src/torsocks.py:394:27: E221 multiple spaces before operator
./src/torsocks.py:397:26: E221 multiple spaces before operator
./src/torsocks.py:399:14: E221 multiple spaces before operator
./src/torsocks.py:400:16: E221 multiple spaces before operator
./src/torsocks.py:401:19: E221 multiple spaces before operator
./src/torsocks.py:402:19: E221 multiple spaces before operator
./src/torsocks.py:403:22: E221 multiple spaces before operator
./src/torsocks.py:410:14: E221 multiple spaces before operator
./src/torsocks.py:411:16: E221 multiple spaces before operator
./src/torsocks.py:412:19: E221 multiple spaces before operator
./src/torsocks.py:413:19: E221 multiple spaces before operator
./src/torsocks.py:414:22: E221 multiple spaces before operator
./src/eventhandler.py:26:1: F401 'socket' imported but unused
./src/eventhandler.py:158:80: E501 line too long (81 > 79 characters)
./src/selectors34.py:56:5: F811 redefinition of unused 'select' from line 15
./src/selectors34.py:109:80: E501 line too long (82 > 79 characters)
./src/six.py:10:80: E501 line too long (80 > 79 characters)
./src/six.py:49:20: F821 undefined name 'basestring'
./src/six.py:50:27: F821 undefined name 'long'
./src/six.py:52:17: F821 undefined name 'unicode'
./src/six.py:238:80: E501 line too long (91 > 79 characters)
./src/six.py:245:80: E501 line too long (93 > 79 characters)
./src/six.py:254:80: E501 line too long (91 > 79 characters)
./src/six.py:265:80: E501 line too long (87 > 79 characters)
./src/six.py:266:80: E501 line too long (96 > 79 characters)
./src/six.py:280:80: E501 line too long (80 > 79 characters)
./src/six.py:281:80: E501 line too long (80 > 79 characters)
./src/six.py:295:80: E501 line too long (82 > 79 characters)
./src/six.py:296:80: E501 line too long (82 > 79 characters)
./src/six.py:297:80: E501 line too long (82 > 79 characters)
./src/six.py:354:80: E501 line too long (80 > 79 characters)
./src/six.py:356:80: E501 line too long (86 > 79 characters)
./src/six.py:374:80: E501 line too long (80 > 79 characters)
./src/six.py:376:80: E501 line too long (86 > 79 characters)
./src/six.py:400:80: E501 line too long (83 > 79 characters)
./src/six.py:424:80: E501 line too long (84 > 79 characters)
./src/six.py:426:80: E501 line too long (90 > 79 characters)
./src/six.py:445:80: E501 line too long (86 > 79 characters)
./src/six.py:447:80: E501 line too long (92 > 79 characters)
./src/six.py:463:80: E501 line too long (92 > 79 characters)
./src/six.py:465:80: E501 line too long (98 > 79 characters)
./src/six.py:471:80: E501 line too long (83 > 79 characters)
./src/six.py:647:16: F821 undefined name 'unicode'
./src/six.py:730:37: F821 undefined name 'basestring'
./src/six.py:733:32: F821 undefined name 'file'
./src/six.py:734:38: F821 undefined name 'unicode'
./src/six.py:744:32: F821 undefined name 'unicode'
./src/six.py:750:32: F821 undefined name 'unicode'
./src/six.py:758:36: F821 undefined name 'unicode'
./src/six.py:762:23: F821 undefined name 'unicode'
./src/six.py:763:21: F821 undefined name 'unicode'
./src/six.py:858:80: E501 line too long (80 > 79 characters)
./src/exitmap.py:154:80: E501 line too long (80 > 79 characters)
./src/exitmap.py:236:80: E501 line too long (80 > 79 characters)
./src/exitmap.py:278:1: E302 expected 2 blank lines, found 1
./src/exitmap.py:295:1: E302 expected 2 blank lines, found 1
./src/exitmap.py:325:18: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:325:18: E221 multiple spaces before operator
./src/exitmap.py:325:26: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:326:17: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:326:17: E221 multiple spaces before operator
./src/exitmap.py:326:26: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:327:21: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:327:21: E221 multiple spaces before operator
./src/exitmap.py:327:26: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:328:24: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:328:26: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:329:21: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:329:21: E221 multiple spaces before operator
./src/exitmap.py:329:26: E251 unexpected spaces around keyword / parameter equals
./src/exitmap.py:336:1: E302 expected 2 blank lines, found 1
./src/relayselector.py:85:1: E302 expected 2 blank lines, found 1
./src/relayselector.py:165:5: E303 too many blank lines (2)
./src/relayselector.py:193:13: E261 at least two spaces before inline comment
./src/relayselector.py:205:80: E501 line too long (80 > 79 characters)
./src/relayselector.py:220:29: E272 multiple spaces before keyword
./src/relayselector.py:220:41: E272 multiple spaces before keyword
./src/relayselector.py:222:29: E272 multiple spaces before keyword
./src/relayselector.py:222:41: E221 multiple spaces before operator
./src/relayselector.py:249:13: E301 expected 1 blank line, found 0
./src/relayselector.py:251:13: E301 expected 1 blank line, found 0
./src/relayselector.py:254:61: E202 whitespace before '}'
./src/relayselector.py:273:35: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:273:37: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:274:31: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:274:31: E221 multiple spaces before operator
./src/relayselector.py:274:37: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:275:32: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:275:32: E221 multiple spaces before operator
./src/relayselector.py:275:37: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:276:30: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:276:30: E221 multiple spaces before operator
./src/relayselector.py:276:37: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:277:31: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:277:31: E221 multiple spaces before operator
./src/relayselector.py:277:37: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:278:30: E251 unexpected spaces around keyword / parameter equals
./src/relayselector.py:278:30: E221 multiple spaces before operator
./src/relayselector.py:278:37: E251 unexpected spaces around keyword / parameter equals
./src/modules/rtt.py:37:1: E266 too many leading '#' for block comment
./src/modules/rtt.py:54:1: E402 module level import not at top of file
./src/modules/rtt.py:55:1: E402 module level import not at top of file
./src/modules/rtt.py:56:1: E402 module level import not at top of file
./src/modules/rtt.py:67:5: F401 'exitmap' imported but unused
./src/modules/rtt.py:69:1: E402 module level import not at top of file
./src/modules/rtt.py:70:1: E402 module level import not at top of file
./src/modules/rtt.py:71:1: E402 module level import not at top of file
./src/modules/rtt.py:72:1: E402 module level import not at top of file
./src/modules/rtt.py:86:1: E302 expected 2 blank lines, found 0
./src/modules/rtt.py:90:1: E402 module level import not at top of file
./src/modules/rtt.py:92:1: E302 expected 2 blank lines, found 1
./src/modules/rtt.py:145:17: E129 visually indented line with same indent as next logical line
./src/modules/rtt.py:209:9: E265 block comment should start with '# '
./src/modules/rtt.py:225:10: E231 missing whitespace after ','
./src/modules/rtt.py:226:26: E701 multiple statements on one line (colon)
./src/modules/rtt.py:278:28: E231 missing whitespace after ','
./src/modules/rtt.py:278:35: E231 missing whitespace after ','
./src/modules/rtt.py:291:1: E302 expected 2 blank lines, found 0
./src/modules/rtt.py:296:42: E701 multiple statements on one line (colon)
./test/test_torsocks.py:24:1: E402 module level import not at top of file
./test/test_torsocks.py:25:1: E402 module level import not at top of file
./test/test_torsocks.py:25:1: F401 'error.SOCKSv5Error' imported but unused
./test/test_util.py:26:1: E402 module level import not at top of file
./test/test_util.py:66:5: E303 too many blank lines (2)
./test/test_relayselector.py:24:1: E402 module level import not at top of file
./test/test_stats.py:28:1: E402 module level import not at top of file
./test/run_tests.py:23:46: E999 SyntaxError: invalid syntax
./test/run_tests.py:36:80: E501 line too long (93 > 79 characters)
./test/run_tests.py:40:80: E501 line too long (86 > 79 characters)
./test/run_tests.py:43:80: E501 line too long (94 > 79 characters)
```

Pep8 violations after:

```
./src/util.py:186:18: E127 continuation line over-indented for visual indent
./src/torsocks.py:35:6: E221 multiple spaces before operator
./src/torsocks.py:36:8: E221 multiple spaces before operator
./src/torsocks.py:96:23: E221 multiple spaces before operator
./src/torsocks.py:98:24: E221 multiple spaces before operator
./src/torsocks.py:99:24: E221 multiple spaces before operator
./src/torsocks.py:100:23: E221 multiple spaces before operator
./src/torsocks.py:193:22: E128 continuation line under-indented for visual indent
./src/torsocks.py:219:22: E128 continuation line under-indented for visual indent
./src/torsocks.py:259:80: E501 line too long (80 > 79 characters)
./src/torsocks.py:386:20: E221 multiple spaces before operator
./src/torsocks.py:387:22: E221 multiple spaces before operator
./src/torsocks.py:388:25: E221 multiple spaces before operator
./src/torsocks.py:389:25: E221 multiple spaces before operator
./src/torsocks.py:391:25: E221 multiple spaces before operator
./src/torsocks.py:392:27: E221 multiple spaces before operator
./src/torsocks.py:395:26: E221 multiple spaces before operator
./src/torsocks.py:401:25: E221 multiple spaces before operator
./src/torsocks.py:402:27: E221 multiple spaces before operator
./src/torsocks.py:405:26: E221 multiple spaces before operator
./src/torsocks.py:407:14: E221 multiple spaces before operator
./src/torsocks.py:408:16: E221 multiple spaces before operator
./src/torsocks.py:409:19: E221 multiple spaces before operator
./src/torsocks.py:410:19: E221 multiple spaces before operator
./src/torsocks.py:411:22: E221 multiple spaces before operator
./src/torsocks.py:418:14: E221 multiple spaces before operator
./src/torsocks.py:419:16: E221 multiple spaces before operator
./src/torsocks.py:420:19: E221 multiple spaces before operator
./src/torsocks.py:421:19: E221 multiple spaces before operator
./src/torsocks.py:422:22: E221 multiple spaces before operator
./src/eventhandler.py:157:80: E501 line too long (81 > 79 characters)
./src/selectors34.py:56:5: F811 redefinition of unused 'select' from line 15
./src/selectors34.py:109:80: E501 line too long (82 > 79 characters)
./src/six.py:49:20: F821 undefined name 'basestring'
./src/six.py:50:27: F821 undefined name 'long'
./src/six.py:52:17: F821 undefined name 'unicode'
./src/six.py:238:80: E501 line too long (91 > 79 characters)
./src/six.py:245:80: E501 line too long (93 > 79 characters)
./src/six.py:254:80: E501 line too long (91 > 79 characters)
./src/six.py:265:80: E501 line too long (87 > 79 characters)
./src/six.py:266:80: E501 line too long (96 > 79 characters)
./src/six.py:280:80: E501 line too long (80 > 79 characters)
./src/six.py:281:80: E501 line too long (80 > 79 characters)
./src/six.py:295:80: E501 line too long (82 > 79 characters)
./src/six.py:296:80: E501 line too long (82 > 79 characters)
./src/six.py:297:80: E501 line too long (82 > 79 characters)
./src/six.py:354:80: E501 line too long (80 > 79 characters)
./src/six.py:356:80: E501 line too long (86 > 79 characters)
./src/six.py:374:80: E501 line too long (80 > 79 characters)
./src/six.py:376:80: E501 line too long (86 > 79 characters)
./src/six.py:400:80: E501 line too long (83 > 79 characters)
./src/six.py:424:80: E501 line too long (84 > 79 characters)
./src/six.py:426:80: E501 line too long (90 > 79 characters)
./src/six.py:445:80: E501 line too long (86 > 79 characters)
./src/six.py:447:80: E501 line too long (92 > 79 characters)
./src/six.py:463:80: E501 line too long (92 > 79 characters)
./src/six.py:465:80: E501 line too long (98 > 79 characters)
./src/six.py:471:80: E501 line too long (83 > 79 characters)
./src/six.py:647:16: F821 undefined name 'unicode'
./src/six.py:730:37: F821 undefined name 'basestring'
./src/six.py:733:32: F821 undefined name 'file'
./src/six.py:734:38: F821 undefined name 'unicode'
./src/six.py:744:32: F821 undefined name 'unicode'
./src/six.py:750:32: F821 undefined name 'unicode'
./src/six.py:758:36: F821 undefined name 'unicode'
./src/six.py:762:23: F821 undefined name 'unicode'
./src/six.py:763:21: F821 undefined name 'unicode'
./src/six.py:858:80: E501 line too long (80 > 79 characters)
./src/exitmap.py:236:80: E501 line too long (80 > 79 characters)
./src/relayselector.py:166:5: E303 too many blank lines (2)
./src/relayselector.py:206:80: E501 line too long (80 > 79 characters)
./src/modules/rtt.py:55:5: F401 'exitmap' imported but unused
./src/modules/rtt.py:147:17: E129 visually indented line with same indent as next logical line
./src/modules/rtt.py:228:26: E701 multiple statements on one line (colon)
./src/modules/rtt.py:300:42: E701 multiple statements on one line (colon)
./test/test_torsocks.py:24:1: E402 module level import not at top of file
./test/test_torsocks.py:25:1: E402 module level import not at top of file
./test/test_torsocks.py:25:1: F401 'error.SOCKSv5Error' imported but unused
./test/test_util.py:26:1: E402 module level import not at top of file
./test/test_util.py:66:5: E303 too many blank lines (2)
./test/test_relayselector.py:24:1: E402 module level import not at top of file
./test/test_stats.py:28:1: E402 module level import not at top of file
./test/run_tests.py:23:46: E999 SyntaxError: invalid syntax
./test/run_tests.py:36:80: E501 line too long (93 > 79 characters)
./test/run_tests.py:40:80: E501 line too long (86 > 79 characters)
./test/run_tests.py:43:80: E501 line too long (94 > 79 characters)
```