### PR TITLE
Makes flake8 standard linting tool

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude = .git, __pycache__, venv
+max-complexity = 25

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
     - pip install -r requirements-dev.txt
     - pip install coveralls
 script:
+    - flake8
     - py.test --cov-report term-missing --cov=src test
 after_success:
   coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
 install:
     - pip install -r requirements.txt
     - pip install -r requirements-dev.txt
-    - pip install coveralls
 script:
     - flake8
     - py.test --cov-report term-missing --cov=src test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 flake8
+coveralls


### PR DESCRIPTION
Makes flake8 standard lint tool

- adds .flake8 to establish lint rules
- adds flake8 to dev reqs
- adds flake8 script to travis build

The ensuing travis build should fail with the `.travis.yml` update due to the flake8 violations